### PR TITLE
Update healthcheck URL to use 0.0.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - HOST=0.0.0.0
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
This fixes the error:

`wget: can't connect to remote host: Connection refused`