### PR TITLE
fix link to dev setup instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Hey! Thanks for wanting to contribute to Networking Toolbox 🎉
 
 ## Getting Started
 
-Checkout the [README](README.md) for setup instructions, it's all very standard (clone, cd, npm install, npm run dev).
+Checkout the [README](https://github.com/Lissy93/networking-toolbox?tab=readme-ov-file#developing) for setup instructions, it's all very standard (clone, cd, npm install, npm run dev).
 
 ## Code Style
 


### PR DESCRIPTION
the relative link wasn't working for me from https://github.com/Lissy93/networking-toolbox?tab=contributing-ov-file , it was trying to send me to a nonexistant top-level README.md