### PR TITLE
Fix/supernet CIDR calculations

### DIFF
--- a/src/lib/utils/supernet-calculations.ts
+++ b/src/lib/utils/supernet-calculations.ts
@@ -152,7 +152,7 @@ function findSupernet(networks: NetworkInput[]): { network: string; cidr: number
 
   // Find the smallest CIDR that can contain all networks
   let supernetCidr = 32;
-  for (let cidr = 1; cidr <= 30; cidr++) {
+  for (let cidr = 30; cidr >= 1; cidr--) {
     const mask = 0xffffffff << (32 - cidr);
     const supernetStart = minAddress & (mask >>> 0);
     const supernetEnd = supernetStart + Math.pow(2, 32 - cidr) - 1;


### PR DESCRIPTION
Invert the loop in findSupernet to find the smallest CIDR that encompasses all networks, not the largest.

Before this change, the loop starts at cidr = 1 and ends at the first CIDR that includes all addresses. Since /1 covers any IPv4 range, it satisfies the condition (supernetStart ≤ minAddress and supernetEnd ≥ maxAddress), leading to its incorrect selection.

Before:
<img width="1164" height="3375" alt="Screen Shot 2025-10-20 at 11 08 30" src="https://github.com/user-attachments/assets/186e89b1-d376-4dd8-bb4c-e45349437adb" />

After:
<img width="1164" height="3375" alt="Screen Shot 2025-10-20 at 11 07 16" src="https://github.com/user-attachments/assets/d5e3836a-46cc-41d3-b910-575b5460a99c" />

