### PR TITLE
style(dhcp-page): remove additional spacing to have consistent padding on header

### DIFF
--- a/src/routes/dhcp/+page.svelte
+++ b/src/routes/dhcp/+page.svelte
@@ -33,9 +33,3 @@
 
   <ToolsGrid tools={dhcpTools} />
 </div>
-
-<style>
-  header {
-    margin-bottom: var(--spacing-md);
-  }
-</style>


### PR DESCRIPTION
This is not much but the header on this page had an extra spacing, which was not the cas eon all other pages. This PR made it consistent so there is no UI glitch when switching tabs.

<img width="1195" height="575" alt="image" src="https://github.com/user-attachments/assets/3cc6debe-addb-4cf6-aeb5-7b24207d60cb" />

